### PR TITLE
Updated options, augroups, and tab completion

### DIFF
--- a/lua/haplolabs/plugins/compe.lua
+++ b/lua/haplolabs/plugins/compe.lua
@@ -69,13 +69,14 @@ end
 _G.tab_complete = function()
   if vim.fn.pumvisible() == 1 then
     return t "<C-n>"
-  elseif vim.fn['vsnip#available'](1) == 1 then
-    return t "<Plug>(vsnip-expand-or-jump)"
+  -- elseif vim.fn['vsnip#available'](1) == 1 then
+  --   return t "<Plug>(vsnip-expand-or-jump)"
   elseif check_back_space() then
     return t "<Tab>"
   else
     return vim.fn['compe#complete']()
   end
+  
 end
 _G.s_tab_complete = function()
   if vim.fn.pumvisible() == 1 then

--- a/lua/haplolabs/utils.lua
+++ b/lua/haplolabs/utils.lua
@@ -1,0 +1,57 @@
+local M = {}
+local cmd = vim.cmd
+
+-- We will create a few autogroup, this function will help to avoid
+-- always writing cmd('augroup^ .. group) etc
+function M.create_augroup(autocmds, name)
+  cmd('augroup ' .. name)
+  cmd('autocmd!')
+  for _, autocmd in ipairs(autocmds) do
+    cmd('autocmd ' .. table.concat(autocmd, ' '))
+  end
+  cmd('augroup END')
+end
+
+-- Add a path to the rtp
+function M.add_rtp(path)
+  local rtp = vim.o.rtp
+  rtp = rtp .. ',' .. path
+end
+
+-- Map a key with optional options
+function M.map(mode, keys, action, options)
+  if options == nil then
+    options = {}
+  end
+  vim.api.nvim_set_keymap(mode, keys, action, options)
+end
+
+-- Map a key to a lua callback
+function M.tap_lua(mode, keys, action, options)
+  if options == nil then
+    options = {}
+  end
+  vim.api.nvim_set_keymap(mode, keys, "<cmd>lua " .. action .. "<cr>", options)
+end
+
+-- Buffer local mappings
+function M.map_buf(mode, keys, action, options, buf_nr)
+  if options == nil then
+    options = {}
+  end
+  local buf = buf_nr or 0
+  vim.api.nvim_set_keymap(buf, mode, keys, action, options)
+ end
+
+function M.map_lua_buf(mode, keys, action, options, buf_nr)
+  if options == nil then
+    options = {}
+  end
+  local buf = buf_nr or 0
+  vim.api.nvim_set_keymap(buf, mode, keys, "<cmd>lua " .. action .. "<cr>", options)
+ end
+
+-- We want to be able to access utils in all our configuration files
+-- so we add the module to the _G global variable
+_G.utils = M
+return M -- Export the module

--- a/lua/haplolabs/vim.lua
+++ b/lua/haplolabs/vim.lua
@@ -114,8 +114,10 @@ local function set_keymaps()
   map('n', '<leader>k', '<CMD>wincmd k<CR>', options)
   map('n', '<leader>l', '<CMD>wincmd l<CR>', options)
 
-  map('n', '<M-S-l>', ':vertical resize -2<CR>', options)
-  map('n', '<M-S-h>', ':vertical resize +2<CR>', options)
+  map('n', '<C-Up>', ':resize -2<CR>', options)
+  map('n', '<C-Down>', ':resize +2<CR>', options)
+  map('n', '<C-Left>', ':vertical resize -2<CR>', options)
+  map('n', '<C-Right>', ':vertical resize +2<CR>', options)
 
   map('v', 'J', [[:m '>+1<cr>gv=gv]], {noremap = true})
   map('v', 'K', [[:m '<-2<cr>gv=gv]], {noremap = true})

--- a/lua/haplolabs/vim.lua
+++ b/lua/haplolabs/vim.lua
@@ -1,9 +1,29 @@
 local function set_augroup()
-  vim.api.nvim_command("augroup WrapInMarkdown")
-  vim.api.nvim_command("autocmd!")
-  vim.api.nvim_command("autocmd FileType markdown setlocal wrap")
-  vim.api.nvim_command("augroup END")
+
+  local utils = require('haplolabs.utils')
+
+  utils.create_augroup({
+    { 'FileType', 'markdown', 'setlocal', 'wrap' },
+    { 'FileType', 'markdown', 'setlocal', 'spell' },
+  }, '_WrapInMarkdown')
+
+  utils.create_augroup({
+    {'FileType', '*', 'setlocal', 'shiftwidth=2'},
+    {
+      'FileType',
+      'ocaml,ocaml.ocaml_inteface,lua,nix,javascript,js,ts,tsx,typscript,typescriptreact,html',
+      'setlocal',
+      'shiftwidth=2'
+    },
+  }, '_Tab2')
+
+  utils.create_augroup({
+    {'BufWinEnter', '*', 'setlocal', 'formatoptions-=c', 'formatoptions-=r', 'formatoptions-=o'},
+    {'BufRead', '*', 'setlocal', 'formatoptions-=c', 'formatoptions-=r', 'formatoptions-=o'},
+    {'BufNewFile', '*', 'setlocal', 'formatoptions-=c', 'formatoptions-=r', 'formatoptions-=o'},
+  }, '_FormatOpts')
 end
+
 
 local function set_vim_g()
   vim.g.mapleader = " "
@@ -14,24 +34,22 @@ local function set_vim_o()
     backup = false,
     ruler = true,
     errorbells = false,
-    expandtab = true,
     smarttab = true,
-    smartindent = true,
-    autoindent = true,
     laststatus = 0,
-    conceallevel = 0,
     hidden = true,
     scrolloff = 3,
-    softtabstop = 2,
     showmode = false,
     termguicolors = true,
     background = 'dark',
-    cursorline = true,
     pumheight = 10,
     cmdheight = 2,
+    lazyredraw = true,
     showtabline = 2,
     hlsearch = false,
-    mouse = 'a'
+    mouse = 'a',
+    backspace = [[indent,eol,start]],
+    splitbelow = true,
+    splitright = true
   }
 
   -- Generic vim.o
@@ -45,23 +63,18 @@ local function set_vim_o()
   vim.opt.formatoptions = vim.opt.formatoptions
     + {
         c = false,
-        o = false,
         r = true,
+        o = false,
       }
 
   -- Not yet in vim.o
   vim.cmd('set encoding=utf8')
-  vim.cmd('set fileencoding=utf8')
   vim.cmd('set nowritebackup')
   vim.cmd('set shiftwidth=2')
-  vim.cmd('set tabstop=2')
   vim.cmd('set secure')
-  vim.cmd('set splitright')
-  vim.cmd('set splitbelow')
   vim.cmd('set updatetime=300')
   vim.cmd('set timeoutlen=500')
   vim.cmd('set t_Co=256')
-  vim.cmd('set nowrap')
   vim.cmd('set iskeyword+=-')
   vim.cmd('set wildmode=longest,list,full')
   vim.cmd('set formatoptions=jql')
@@ -73,11 +86,23 @@ local function set_vim_wo()
   vim.wo.number = true
   vim.wo.relativenumber = true
   vim.wo.wrap = false
+  vim.wo.list = true
+  vim.wo.cursorline = true
+  vim.wo.conceallevel = 0
+  vim.wo.scrolloff = 3
 end
 
--- local function set_vim_bo()
---   vim.bo.formatoptions = 'jql'
--- end
+local function set_vim_bo()
+  vim.bo.autoindent = true
+  vim.bo.expandtab = true
+  vim.bo.softtabstop = 2
+  vim.bo.tabstop = 2
+  vim.bo.smartindent = true
+  vim.bo.modeline = false
+  vim.swapfile = false
+  vim.bo.synmaxcol = 4000
+  vim.bo.fileencoding = 'utf8'
+end
 
 local function set_keymaps()
   local map = vim.api.nvim_set_keymap
@@ -88,8 +113,15 @@ local function set_keymaps()
   map('n', '<leader>j', '<CMD>wincmd j<CR>', options)
   map('n', '<leader>k', '<CMD>wincmd k<CR>', options)
   map('n', '<leader>l', '<CMD>wincmd l<CR>', options)
+
   map('n', '<M-S-l>', ':vertical resize -2<CR>', options)
   map('n', '<M-S-h>', ':vertical resize +2<CR>', options)
+
+  map('v', 'J', [[:m '>+1<cr>gv=gv]], {noremap = true})
+  map('v', 'K', [[:m '<-2<cr>gv=gv]], {noremap = true})
+
+  map('n', '<A-Tab>', ':tabnext<cr>', {noremap = true})
+  map('n', '<A-S-Tab>', ':tabprev<cr>', {noremap = true})
 
   -- Easy CAPS
   map('i', '<C-u>', '<ESC>viwUi', options)
@@ -102,7 +134,7 @@ local function init()
   set_vim_g()
   set_vim_o()
   set_vim_wo()
-  -- set_vim_bo()
+  set_vim_bo()
   set_keymaps()
 end
 

--- a/lua/haplolabs/vim.lua
+++ b/lua/haplolabs/vim.lua
@@ -119,11 +119,11 @@ local function set_keymaps()
   map('n', '<C-Left>', ':vertical resize -2<CR>', options)
   map('n', '<C-Right>', ':vertical resize +2<CR>', options)
 
-  map('v', 'J', [[:m '>+1<cr>gv=gv]], {noremap = true})
-  map('v', 'K', [[:m '<-2<cr>gv=gv]], {noremap = true})
+  map('v', 'J', [[:m '>+1<cr>gv=gv]], options)
+  map('v', 'K', [[:m '<-2<cr>gv=gv]], options)
 
-  map('n', '<A-Tab>', ':tabnext<cr>', {noremap = true})
-  map('n', '<A-S-Tab>', ':tabprev<cr>', {noremap = true})
+  map('n', '<A-Tab>', ':tabnext<cr>', options)
+  map('n', '<A-S-Tab>', ':tabprev<cr>', options)
 
   -- Easy CAPS
   map('i', '<C-u>', '<ESC>viwUi', options)


### PR DESCRIPTION
Add utils.lua for functions such as adding `augroups` for `autocmd` groupings.

Updated options to more correctly match global {vim.o), local to buffer (vim.bo), and local to window {vim.wo) contexts.

Also removed vsnip tab completion in `plugins/compe.lua` to fix tab issues. This needs to be revisited.